### PR TITLE
Fix preRelease string in copy

### DIFF
--- a/src/Traits/Copyable.php
+++ b/src/Traits/Copyable.php
@@ -34,7 +34,7 @@ trait Copyable
             $major == null ? $this->major : $major,
             $minor == null ? $this->minor : $minor,
             $patch == null ? $this->patch : $patch,
-            $preRelease === null ? (string)$this->preRelease : $preRelease,
+            $preRelease === null ? $this->preRelease : $preRelease,
             $buildMeta === null ? $this->buildMeta : $buildMeta
         );
     }


### PR DESCRIPTION
$v = Version::parse('1.1.1');
$b = $v->copy(null, null, 2);
echo $b // 1.1.2-1

I don't want the -1 to be there